### PR TITLE
[TypeScript][Generator BotBuilder Assistant] Update dependency

### DIFF
--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/package-lock.json
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/package-lock.json
@@ -1633,11 +1633,6 @@
         "function-bind": "^1.1.1"
       }
     },
-    "has-color": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
-      "integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8="
-    },
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -2735,16 +2730,6 @@
         "path-key": "^2.0.0"
       }
     },
-    "npmignore": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/npmignore/-/npmignore-0.2.0.tgz",
-      "integrity": "sha1-zZcbRd1HReYxZVClEXzaDd2NZs8=",
-      "requires": {
-        "array-uniq": "^1.0.1",
-        "minimist": "^1.1.0",
-        "verbalize": "^0.1.2"
-      }
-    },
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
@@ -3717,11 +3702,6 @@
         "safe-buffer": "~5.1.0"
       }
     },
-    "strip-ansi": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
-      "integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE="
-    },
     "strip-bom": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
@@ -4079,31 +4059,6 @@
       "requires": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
-      }
-    },
-    "verbalize": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/verbalize/-/verbalize-0.1.2.tgz",
-      "integrity": "sha1-Fl/aRkAzFUj46ZCx1+FDletyAgc=",
-      "requires": {
-        "chalk": "~0.4.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
-          "integrity": "sha1-yxAt8cVvUSPquLZ817mAJ6AnkXg="
-        },
-        "chalk": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
-          "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
-          "requires": {
-            "ansi-styles": "~1.0.0",
-            "has-color": "~0.1.0",
-            "strip-ansi": "~0.1.0"
-          }
-        }
       }
     },
     "vinyl": {

--- a/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/package.json
+++ b/templates/Virtual-Assistant-Template/typescript/generator-botbuilder-assistant/package.json
@@ -31,7 +31,6 @@
   "dependencies": {
     "chalk": "^2.4.2",
     "lodash": "^4.17.11",
-    "npmignore": "^0.2.0",
     "yeoman-generator": "^3.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Purpose
Update dependencies by removing unused dependencies

## Changes
  - Remove the dependency `npmignore`

![image](https://user-images.githubusercontent.com/40918752/60543266-3c561480-9cec-11e9-8f63-0f2ddb2b43f2.png)

## Testing Steps
1. Go to  `.\templates\Virtual-Assistant-Template\typescript\generator-botbuilder-assistant`.
1. Open the console.
1. Execute `npm install` to install dependencies.
1. Execute `npm run test`.
1. Verify that the tests passed successfully.