### PR TITLE
[Documentation] Fix broken links

### DIFF
--- a/docs/reference/skills/architecture.md
+++ b/docs/reference/skills/architecture.md
@@ -23,7 +23,7 @@ A key design goal for Skills was to maintain the consistent Activity protocol an
 
 ### Dispatcher
 
-The [Dispatcher](/docs/reference/assistant/dispatcher.md) plays a central role to enabling a Bot to understand how to best process a given utterance. The Dispatch through use of the [Skill CLI](/docs/reference/assistant/skillcli.md) is updated with triggering utterances for a given Skill and a new Dispatch intent is created for a given Skill. An example of a Dispatch model with a point of interest skill having been added is shown below.
+The [Dispatcher](/docs/reference/assistant/dispatcher.md) plays a central role to enabling a Bot to understand how to best process a given utterance. The Dispatch through use of the [Skill CLI](/docs/howto/skills/botskills.md) is updated with triggering utterances for a given Skill and a new Dispatch intent is created for a given Skill. An example of a Dispatch model with a point of interest skill having been added is shown below.
 
 ![Dispatch with Skill Example](/docs/media/skillarchitecturedispatchexample.png)
 
@@ -72,7 +72,7 @@ This dialog remains active on the Virtual Assistant's `DialogStack`, ensuring th
 
 When an `EndOfConversation` event is sent from the Skill, it tears down the `SkillDialog` and returns control back to the Virtual Assistant.
 
-See the [SkillAuthentication](/docs/reference/assistant/skillauthentication.md) section for information on how Bot->Skill invocation is secured.
+See the [SkillAuthentication](/docs/reference/skills/skillauthentication.md) section for information on how Bot->Skill invocation is secured.
 
 ## Skill Middleware
 

--- a/docs/reference/skills/architecture.md
+++ b/docs/reference/skills/architecture.md
@@ -23,7 +23,7 @@ A key design goal for Skills was to maintain the consistent Activity protocol an
 
 ### Dispatcher
 
-The [Dispatcher](/docs/reference/assistant/dispatcher.md) plays a central role to enabling a Bot to understand how to best process a given utterance. The Dispatch through use of the [Skill CLI](/docs/howto/skills/botskills.md) is updated with triggering utterances for a given Skill and a new Dispatch intent is created for a given Skill. An example of a Dispatch model with a point of interest skill having been added is shown below.
+The Dispatcher plays a central role to enabling a Bot to understand how to best process a given utterance. The Dispatch through use of the [Skill CLI](/docs/howto/skills/botskills.md) is updated with triggering utterances for a given Skill and a new Dispatch intent is created for a given Skill. An example of a Dispatch model with a point of interest skill having been added is shown below.
 
 ![Dispatch with Skill Example](/docs/media/skillarchitecturedispatchexample.png)
 


### PR DESCRIPTION
## Purpose
Update the documentation with their corresponding links because they are broken.

## Changes
  - Remove link of `Dispatcher`.
  - Fix the links on `Skill CLI`.
  - Fix the links on `SkillAuthentication`.

## Testing Steps
1. Go to  `./docs/reference/skills/architecture.md`.
1. Read and check that the documentation have the links working successfully.