### PR TITLE
[Botskills] Fix line endings for test temporal files

### DIFF
--- a/tools/botskills/test/authentication.test.js
+++ b/tools/botskills/test/authentication.test.js
@@ -8,13 +8,14 @@ const { writeFileSync } = require("fs");
 const { join, resolve } = require("path");
 const sandbox = require("sinon").createSandbox();
 const { TestLogger } = require("./helpers/testLogger");
+const { normalizeContent } = require("./helpers/normalizeUtils");
 const { AuthenticationUtils } = require("../lib/utils");
 const authenticationUtils = new AuthenticationUtils();
 const emptyAzureAuthSettings = JSON.stringify(require(resolve(__dirname, join("mocks", "azureAuthSettings", "emptyAuthSettings.json"))));
 const filledAzureAuthSettings = JSON.stringify(require(resolve(__dirname, join("mocks", "azureAuthSettings", "filledAuthSettings.json"))));
 const appShowReplyUrl = JSON.stringify(require(resolve(__dirname, join("mocks", "appShowReplyUrl", "emptyAppShowReplyUrl.json"))));
 
-const noAuthConnectionAppsettings = JSON.stringify(
+const noAuthConnectionAppsettings = normalizeContent(JSON.stringify(
     {
         "microsoftAppId": "",
         "microsoftAppPassword": "",
@@ -36,10 +37,41 @@ const noAuthConnectionAppsettings = JSON.stringify(
             "key": ""
         }
     },
-    null, 4);
+    null, 4));
+
+const authConnectionAppsettings = normalizeContent(JSON.stringify(
+    {
+        "microsoftAppId": "",
+        "microsoftAppPassword": "",
+        "appInsights": {
+            "appId": "",
+            "instrumentationKey": ""
+        },
+        "blobStorage": {
+            "connectionString": "",
+            "container": ""
+        },
+        "cosmosDb": {
+            "authkey": "",
+            "collectionId": "",
+            "cosmosDBEndpoint": "",
+            "databaseId": ""
+        },
+        "contentModerator": {
+            "key": ""
+        },
+        "oauthConnections": [
+            {
+                "name": "Outlook",
+                "provider": "Azure Active Directory v2"
+            }
+        ]
+    },
+    null,4));
 
 function undoChangesInTemporalFiles() {
     writeFileSync(resolve(__dirname, join("mocks", "appsettings", "noAuthConnectionAppsettings.json")), noAuthConnectionAppsettings);
+    writeFileSync(resolve(__dirname, join("mocks", "appsettings", "authConnectionAppsettings.json")), authConnectionAppsettings);
 }
 
 describe("The authentication util", function() {

--- a/tools/botskills/test/connect.test.js
+++ b/tools/botskills/test/connect.test.js
@@ -20,7 +20,8 @@ const filledSkills = JSON.stringify(
             }
         ]
     },
-    null, 4);
+    null, 4).replace(/\r\n/gm, "\n")    //normalize
+    .replace(/\n/gm, "\r\n")  //CR+LF  -  Windows EOL;
 
 function undoChangesInTemporalFiles() {
     writeFileSync(resolve(__dirname, join("mocks", "virtualAssistant", "filledSkills.json")), filledSkills);

--- a/tools/botskills/test/connect.test.js
+++ b/tools/botskills/test/connect.test.js
@@ -8,8 +8,9 @@ const { writeFileSync } = require("fs");
 const { join, resolve } = require("path");
 const sandbox = require("sinon").createSandbox();
 const testLogger = require("./helpers/testLogger");
+const { normalizeContent } = require("./helpers/normalizeUtils");
 const botskills = require("../lib/index");
-const filledSkills = JSON.stringify(
+const filledSkills = normalizeContent(JSON.stringify(
     {
         "skills": [
             {
@@ -20,8 +21,7 @@ const filledSkills = JSON.stringify(
             }
         ]
     },
-    null, 4).replace(/\r\n/gm, "\n")    //normalize
-    .replace(/\n/gm, "\r\n")  //CR+LF  -  Windows EOL;
+    null, 4));
 
 function undoChangesInTemporalFiles() {
     writeFileSync(resolve(__dirname, join("mocks", "virtualAssistant", "filledSkills.json")), filledSkills);

--- a/tools/botskills/test/disconnect.test.js
+++ b/tools/botskills/test/disconnect.test.js
@@ -8,8 +8,9 @@ const { writeFileSync } = require("fs");
 const { join, resolve } = require("path");
 const sandbox = require("sinon").createSandbox();
 const testLogger = require("./helpers/testLogger");
+const { normalizeContent } = require("./helpers/normalizeUtils");
 const botskills = require("../lib/index");
-const filledDispatch = JSON.stringify(
+const filledDispatch = normalizeContent(JSON.stringify(
     {
         "services": [
             {
@@ -21,9 +22,9 @@ const filledDispatch = JSON.stringify(
             "1"
         ]
     },
-    null, 4);
+    null, 4));
 
-const filledSkills = JSON.stringify(
+const filledSkills = normalizeContent(JSON.stringify(
     {
         "skills": [
             {
@@ -34,19 +35,18 @@ const filledSkills = JSON.stringify(
             }
         ]
     },
-    null, 4)
+    null, 4));
 
 function undoChangesInTemporalFiles() {
     writeFileSync(resolve(__dirname, join("mocks", "success", "dispatch", "filledDispatchNoJson.dispatch")), filledDispatch);
+    writeFileSync(resolve(__dirname, join("mocks", "success", "dispatch", "filledDispatch.dispatch")), filledDispatch);
     writeFileSync(resolve(__dirname, join("mocks", "virtualAssistant", "filledSkills.json")), filledSkills);
 }
 
 describe("The disconnect command", function () {
     
     beforeEach(function() {
-        writeFileSync(resolve(__dirname, join("mocks", "success", "dispatch", "filledDispatch.dispatch")),filledDispatch);
         undoChangesInTemporalFiles();
-        
         this.logger = new testLogger.TestLogger();
         this.disconnector = new botskills.DisconnectSkill(this.logger);
         this.refreshSkillStub = sandbox.stub(this.disconnector.refreshSkill, "refreshSkill");

--- a/tools/botskills/test/helpers/normalizeUtils.js
+++ b/tools/botskills/test/helpers/normalizeUtils.js
@@ -3,6 +3,9 @@
  * Licensed under the MIT License.
  */
 
+/**
+ * Normalize the line endings of the content received
+ */
 function normalizeContent(content) {
     return content.replace(/\r\n/gm, "\n") //normalize
                   .replace(/\n/gm, "\r\n"); //CR+LF - Windows EOL;

--- a/tools/botskills/test/helpers/normalizeUtils.js
+++ b/tools/botskills/test/helpers/normalizeUtils.js
@@ -1,0 +1,11 @@
+/**
+ * Copyright(c) Microsoft Corporation.All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+function normalizeContent(content) {
+    return content.replace(/\r\n/gm, "\n") //normalize
+                  .replace(/\n/gm, "\r\n"); //CR+LF - Windows EOL;
+}
+
+exports.normalizeContent = normalizeContent;

--- a/tools/botskills/test/list.test.js
+++ b/tools/botskills/test/list.test.js
@@ -7,8 +7,9 @@ const { strictEqual } = require("assert");
 const { writeFileSync } = require("fs");
 const { join, resolve } = require("path");
 const testLogger = require("./helpers/testLogger");
+const { normalizeContent } = require("./helpers/normalizeUtils");
 const botskills = require("../lib/index");
-const filledSkills = JSON.stringify(
+const filledSkills = normalizeContent(JSON.stringify(
     {
         "skills": [
             {
@@ -19,7 +20,7 @@ const filledSkills = JSON.stringify(
             }
         ]
     },
-    null, 4)
+    null, 4));
 
 function undoChangesInTemporalFiles() {
     writeFileSync(resolve(__dirname, join("mocks", "virtualAssistant", "filledSkills.json")), filledSkills);

--- a/tools/botskills/test/mocks/success/dispatch/filledDispatch.dispatch
+++ b/tools/botskills/test/mocks/success/dispatch/filledDispatch.dispatch
@@ -1,4 +1,11 @@
 {
-    "services": [],
-    "serviceIds": []
+    "services": [
+        {
+            "name": "testDispatch",
+            "id": "1"
+        }
+    ],
+    "serviceIds": [
+        "1"
+    ]
 }

--- a/tools/botskills/test/update.test.js
+++ b/tools/botskills/test/update.test.js
@@ -8,8 +8,9 @@ const { writeFileSync } = require("fs");
 const { join, resolve } = require("path");
 const sandbox = require("sinon").createSandbox();
 const testLogger = require("./helpers/testLogger");
+const { normalizeContent } = require("./helpers/normalizeUtils");
 const botskills = require("../lib/index");
-const filledSkills =  JSON.stringify(
+const filledSkills = normalizeContent(JSON.stringify(
     {
         "skills": [
             {
@@ -20,7 +21,7 @@ const filledSkills =  JSON.stringify(
             }
         ]
     },
-    null, 4);
+    null, 4));
 
 function undoChangesInTemporalFiles() {
     writeFileSync(resolve(__dirname, join("mocks", "virtualAssistant", "filledSkills.json")), filledSkills);


### PR DESCRIPTION
### Purpose
*What is the context of this pull request? Why is it being done?*
There were `test temporal files` which were updated during the test execution, and appeared to be committed.

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*
- Add `normalizeUtils` file which contains the functionality to normalize the `line endings` of the respectively content.
- Update the tests to use that utils
- Update `dispatch test` file

### Tests
*Is this covered by existing tests or new ones? If no, why not?*
This functionality is used in the tests.

### Testing Steps
1. Go to `.\botframework-solutions\tools\botskills`
1. Execute `npm install`
1. Execute `npm run build`
1. Execute `npm run test`
1. Check that all the tests are passing successfully
1. Check that there is no temporal file to be committed.

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*
\-
### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [X] I have added or updated the appropriate tests	
- [ ] I have updated related documentation

#### Bots
- [ ] I have validated that new and updated responses use appropriate [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) and [InputHint](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) properties to ensure a high-quality speech-first experience
- [ ] I have replicated language model changes across the English, French, Italian, German, Spanish, and Chinese `.lu` files and validated that deployment is successful

#### Deployment Scripts
- [ ] I have replicated my changes in the **Virtual Assistant Template** and **Sample** projects
- [ ] I have replicated my changes in the **Skill Template** and **Sample** projects
